### PR TITLE
Standardize naming to 'Speedrun Ethereum'

### DIFF
--- a/packages/nextjs/pages/projects.tsx
+++ b/packages/nextjs/pages/projects.tsx
@@ -14,7 +14,7 @@ const projects = [
     github: "https://github.com/scaffold-eth/scaffold-eth-2",
   },
   {
-    name: "SpeedRunEthereum",
+    name: "Speedrun Ethereum",
     description: "A platform to learn how to build on Ethereum; the superpowers and the gotchas.",
     link: "https://speedrunethereum.com",
     github: "https://github.com/BuidlGuidl/SpeedRunEthereum",


### PR DESCRIPTION
Replace inconsistent variations (SpeedRunEthereum, SpeedRun Ethereum, Speed Run Ethereum) with the standardized form 'Speedrun Ethereum'.

Preserved:
- speedrunethereum.com domain
- Repository URLs
- Lowercase references in links